### PR TITLE
Rename clip to clip_raster

### DIFF
--- a/docs/raster_processing/clipping.md
+++ b/docs/raster_processing/clipping.md
@@ -1,3 +1,3 @@
-# Clip
+# Clip raster
 
 ::: eis_toolkit.raster_processing.clipping

--- a/eis_toolkit/raster_processing/clipping.py
+++ b/eis_toolkit/raster_processing/clipping.py
@@ -11,7 +11,7 @@ from eis_toolkit.exceptions import NonMatchingCrsException, NotApplicableGeometr
 
 
 # The core clipping functionality. Used internally by clip.
-def _clip(  # type: ignore[no-any-unimported] # noqa: E261
+def _clip_raster(  # type: ignore[no-any-unimported] # noqa: E261
     raster: rasterio.io.DatasetReader, geometries: Iterable
 ) -> Tuple[np.ndarray, dict]:
     out_image, out_transform = mask(dataset=raster, shapes=geometries, crop=True, all_touched=True)
@@ -23,7 +23,7 @@ def _clip(  # type: ignore[no-any-unimported] # noqa: E261
     return out_image, out_meta
 
 
-def clip(  # type: ignore[no-any-unimported] # noqa: E261,E262
+def clip_raster(  # type: ignore[no-any-unimported] # noqa: E261,E262
     raster: rasterio.io.DatasetReader, geodataframe: geopandas.GeoDataFrame
 ) -> Tuple[np.ndarray, dict]:
     """Clips a raster with a geodataframe.
@@ -53,7 +53,7 @@ def clip(  # type: ignore[no-any-unimported] # noqa: E261,E262
     ):
         raise NotApplicableGeometryTypeException
 
-    out_image, out_meta = _clip(
+    out_image, out_meta = _clip_raster(
         raster=raster,
         geometries=geometries,
     )

--- a/tests/clip_test.py
+++ b/tests/clip_test.py
@@ -3,7 +3,7 @@ import numpy as np
 from pathlib import Path
 import rasterio
 import geopandas
-from eis_toolkit.raster_processing.clipping import clip
+from eis_toolkit.raster_processing.clipping import clip_raster
 from eis_toolkit.exceptions import NonMatchingCrsException, NotApplicableGeometryTypeException
 
 
@@ -17,12 +17,12 @@ wrong_crs_polygon_path = parent_dir.joinpath("data/remote/small_area.geojson")
 output_raster_path = parent_dir.joinpath("data/local/test.tif")
 
 
-def test_clip():
+def test_clip_raster():
     """Test clip functionality with geotiff raster and shapefile polygon."""
     geodataframe = geopandas.read_file(polygon_path)
 
     with rasterio.open(raster_path) as raster:
-        out_image, out_meta = clip(
+        out_image, out_meta = clip_raster(
             raster=raster,
             geodataframe=geodataframe,
         )
@@ -39,23 +39,23 @@ def test_clip():
         assert result.bounds[3] == 6671364.0
 
 
-def test_clip_wrong_geometry_type():
+def test_clip_raster_wrong_geometry_type():
     """Tests that non-polygon geometry raises the correct exception."""
     with pytest.raises(NotApplicableGeometryTypeException):
         point = geopandas.read_file(point_path)
         with rasterio.open(raster_path) as raster:
-            clip(
+            clip_raster(
                 raster=raster,
                 geodataframe=point,
             )
 
 
-def test_clip_different_crs():
+def test_clip_raster_different_crs():
     """Test that a crs mismatch raises the correct exception."""
     with pytest.raises(NonMatchingCrsException):
         wrong_crs_polygon = geopandas.read_file(wrong_crs_polygon_path)
         with rasterio.open(raster_path) as raster:
-            clip(
+            clip_raster(
                 raster=raster,
                 geodataframe=wrong_crs_polygon,
             )


### PR DESCRIPTION
When going through these PRs I started to wonder that maybe this function should be named clip_raster since we are going to implement one function also for clipping a vector file with polygons..

Boring PR because it contains just renamings but please take a look at it anyways and comment if you do not agree with this change in naming policy (let's add _raster / _vector if we are going to implement two "versions" for the same functionality). If you consent, just merge directly to the master.