### PR TITLE
Implement a draft command-line interface for `eis_toolkit`

### DIFF
--- a/eis_toolkit/__main__.py
+++ b/eis_toolkit/__main__.py
@@ -1,0 +1,4 @@
+from eis_toolkit.cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/eis_toolkit/cli.py
+++ b/eis_toolkit/cli.py
@@ -1,9 +1,9 @@
+"""Command-line interface for eis_toolkit."""
 import json
 from pathlib import Path
 
 import click
 import geopandas as gpd
-import jsonschema
 import rasterio
 
 from eis_toolkit.raster_processing.clipping import clip_raster
@@ -62,26 +62,28 @@ def cli_clip_raster_config(config_file: str):
 
     # I added an example on how to validate the configuration passed from a config file.
     # It uses the jsonschema library, which was, like click already a dependency
-    schema = {
-        "type": "object",
-        "properties": {
-            "raster_file": {
-                "type": "string",
-                "minLength": 1,
-            },
-            "geodataframe_file": {
-                "type": "string",
-                "minLength": 1,
-            },
-            "output_raster_file": {
-                "type": "string",
-                "minLength": 1,
-            },
-        },
-        "required": ["raster_file", "geodataframe_file", "output_raster_file"],
-    }
+    # in poetry.lock but not in requirements.txt so I commented this out to avoid
+    # ci errors.
+    # schema = {
+    #     "type": "object",
+    #     "properties": {
+    #         "raster_file": {
+    #             "type": "string",
+    #             "minLength": 1,
+    #         },
+    #         "geodataframe_file": {
+    #             "type": "string",
+    #             "minLength": 1,
+    #         },
+    #         "output_raster_file": {
+    #             "type": "string",
+    #             "minLength": 1,
+    #         },
+    #     },
+    #     "required": ["raster_file", "geodataframe_file", "output_raster_file"],
+    # }
 
-    jsonschema.validate(instance=loaded_config, schema=schema)
+    # jsonschema.validate(instance=loaded_config, schema=schema)
 
     click.echo(loaded_config)
 

--- a/eis_toolkit/cli.py
+++ b/eis_toolkit/cli.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import click
+import geopandas as gpd
+import rasterio
+
+from eis_toolkit.raster_processing.clipping import clip_raster
+
+EXISTING_CLICK_FILE = click.Path(exists=True, file_okay=True, dir_okay=False, readable=True)
+
+
+@click.group()
+def cli():
+    """Click group to nest subcommands under one interface."""
+    pass
+
+
+@cli.command()
+@click.argument("raster_path", nargs=1, type=EXISTING_CLICK_FILE)
+@click.argument("geodataframe_path", nargs=1, type=EXISTING_CLICK_FILE)
+@click.option("--output-raster-path", type=click.Path(), required=True)
+def cli_clip_raster(raster_path: Path, geodataframe_path: Path, output_raster_path: Path):
+    """Clip a raster at ``raster_path`` with geometries in ``geodataframe_path``."""
+
+    click.echo(f"Reading geodataframe at {geodataframe_path}.")
+    geodataframe = gpd.read_file(geodataframe_path)
+
+    click.echo(f"Opening raster at {raster_path}.")
+    with rasterio.open(raster_path) as raster:
+        out_image, out_meta = clip_raster(
+            raster=raster,
+            geodataframe=geodataframe,
+        )
+    click.echo(f"Writing raster to {output_raster_path}.")
+    with rasterio.open(output_raster_path, "w", **out_meta) as dest:
+        dest.write(out_image)

--- a/eis_toolkit/cli.py
+++ b/eis_toolkit/cli.py
@@ -1,7 +1,9 @@
+import json
 from pathlib import Path
 
 import click
 import geopandas as gpd
+import jsonschema
 import rasterio
 
 from eis_toolkit.raster_processing.clipping import clip_raster
@@ -15,13 +17,7 @@ def cli():
     pass
 
 
-@cli.command()
-@click.argument("raster_path", nargs=1, type=EXISTING_CLICK_FILE)
-@click.argument("geodataframe_path", nargs=1, type=EXISTING_CLICK_FILE)
-@click.option("--output-raster-path", type=click.Path(), required=True)
-def cli_clip_raster(raster_path: Path, geodataframe_path: Path, output_raster_path: Path):
-    """Clip a raster at ``raster_path`` with geometries in ``geodataframe_path``."""
-
+def _cli_clip_raster(raster_path: Path, geodataframe_path: Path, output_raster_path: Path):
     click.echo(f"Reading geodataframe at {geodataframe_path}.")
     geodataframe = gpd.read_file(geodataframe_path)
 
@@ -34,3 +30,65 @@ def cli_clip_raster(raster_path: Path, geodataframe_path: Path, output_raster_pa
     click.echo(f"Writing raster to {output_raster_path}.")
     with rasterio.open(output_raster_path, "w", **out_meta) as dest:
         dest.write(out_image)
+
+
+@cli.command()
+@click.argument("raster_file", nargs=1, type=EXISTING_CLICK_FILE)
+@click.argument("geodataframe_file", nargs=1, type=EXISTING_CLICK_FILE)
+@click.option("--output-raster-file", type=click.Path(), required=True)
+def cli_clip_raster(raster_file: str, geodataframe_file: str, output_raster_file: str):
+    """Clip a raster at ``raster_path`` with geometries in ``geodataframe_path``."""
+    raster_path, geodataframe_path, output_raster_path = (
+        Path(raster_file),
+        Path(geodataframe_file),
+        Path(output_raster_file),
+    )
+    _cli_clip_raster(
+        raster_path=raster_path, geodataframe_path=geodataframe_path, output_raster_path=output_raster_path
+    )
+
+
+@cli.command()
+@click.argument("config_file", nargs=1, type=EXISTING_CLICK_FILE)
+def cli_clip_raster_config(config_file: str):
+    """Clip a raster at raster_path with arguments from config_file.
+
+    config_file should be a path to a valid JSON file with
+    needed arguments for the clip_raster function.
+    """
+    assert isinstance(config_file, str)
+    config_path = Path(config_file)
+    loaded_config = json.loads(config_path.read_text())
+
+    # I added an example on how to validate the configuration passed from a config file.
+    # It uses the jsonschema library, which was, like click already a dependency
+    schema = {
+        "type": "object",
+        "properties": {
+            "raster_file": {
+                "type": "string",
+                "minLength": 1,
+            },
+            "geodataframe_file": {
+                "type": "string",
+                "minLength": 1,
+            },
+            "output_raster_file": {
+                "type": "string",
+                "minLength": 1,
+            },
+        },
+        "required": ["raster_file", "geodataframe_file", "output_raster_file"],
+    }
+
+    jsonschema.validate(instance=loaded_config, schema=schema)
+
+    click.echo(loaded_config)
+
+    geodataframe_path = Path(loaded_config["geodataframe_file"])
+    raster_path = Path(loaded_config["raster_file"])
+    output_raster_path = Path(loaded_config["output_raster_file"])
+
+    _cli_clip_raster(
+        raster_path=raster_path, geodataframe_path=geodataframe_path, output_raster_path=output_raster_path
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ keywords = [
     "Packages"
 ]
 
+[tool.poetry.scripts]
+eis-toolkit = "eis_toolkit.__main__:cli"
+
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 gdal = "3.4.3"

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,0 +1,108 @@
+"""Tests for eis_toolkit.cli."""
+import json
+from contextlib import nullcontext
+from pathlib import Path
+from traceback import print_tb
+from typing import ContextManager
+
+import pytest
+import rasterio
+from click.testing import CliRunner, Result
+
+from eis_toolkit.cli import cli
+
+CLICK_RUNNER = CliRunner()
+
+RASTER_FILE_PATH = Path("tests/data/remote/small_raster.tif")
+GEODATAFRAME_FILE_PATH = Path("tests/data/remote/small_area.shp")
+CONFIG_FILE_PATH = Path("tests/data/remote/clip_raster_cli_test_config.json")
+
+
+def click_error_print(result: Result):
+    """Print click result traceback."""
+    # If exit_code is zero then the cli execution succeeded
+    # If it is not zero then the execution failed
+    if result.exit_code == 0:
+        return
+
+    # Print the Python traceback related to failed execution
+    assert result.exc_info is not None
+    _, _, tb = result.exc_info
+    print_tb(tb)
+
+    # Print the stdout of the execution
+    print(result.output)
+    assert result.exception is not None
+
+    # Raise the collected Python exception that was raised
+    raise result.exception
+
+
+@pytest.mark.parametrize(
+    "raster_file_path,geodataframe_file_path,raises",
+    [
+        # Using the contextmanagers nullcontext and pytest.raises, the tests
+        # can be conditionalized to both error and succeed based on the
+        # parameter (nullcontext == succeed)
+        (RASTER_FILE_PATH, GEODATAFRAME_FILE_PATH, nullcontext()),
+        (Path("invalid/path/to/nowhere.tif"), Path("invalid/path/to/nowhere.shp"), pytest.raises(SystemExit)),
+    ],
+)
+def test_cli_clip_raster(raster_file_path: Path, geodataframe_file_path: Path, raises: ContextManager, tmp_path: Path):
+    """Test cli_clip_raster click entrypoint."""
+    # tmp_path is a pytest fixture that is always a temporary directory path on
+    # the file system if is put in the function signature
+    output_raster_path = tmp_path / "clipped_raster.tif"
+
+    # Define the arguments for the command-line execution
+    args = [
+        # The first arg defines which subcommand to use
+        "cli-clip-raster",
+        str(raster_file_path),
+        str(geodataframe_file_path),
+        f"--output-raster-file={output_raster_path}",
+    ]
+    # Run the eis_toolkit.cli:cli click entrypoint function
+    result = CLICK_RUNNER.invoke(cli=cli, args=args)
+
+    # If error is expected, raises will equal to pytest.raises(<exception>)
+    # where the <exception> can e.g. be FileNotFoundError. For click executions
+    # is is always/usually SystemExit
+    with raises:
+        # This function will error and print tracebacks and exceptions if the
+        # execution fails
+        click_error_print(result=result)
+
+        # Check that the expected result occurred
+        assert output_raster_path.exists()
+        assert output_raster_path.is_file()
+
+        with rasterio.open(output_raster_path, mode="r") as out_raster, rasterio.open(
+            raster_file_path, mode="r"
+        ) as src_raster:
+            # Check that coordinate reference system is maintained
+            assert out_raster.meta["crs"] == src_raster.meta["crs"]
+
+
+@pytest.mark.parametrize("config_file", [CONFIG_FILE_PATH])
+def test_cli_clip_raster_config(config_file: Path):
+    """Test cli_clip_raster click entrypoint."""
+    # Define the arguments for the command-line execution
+    args = [
+        # The first arg defines which subcommand to use
+        "cli-clip-raster-config",
+        str(config_file),
+    ]
+    # Run the eis_toolkit.cli:cli click entrypoint function
+    result = CLICK_RUNNER.invoke(cli=cli, args=args)
+
+    # This function will error and print tracebacks and exceptions if the
+    # execution fails
+    click_error_print(result=result)
+
+    # Need to to parse the config here to
+    output_raster_path = Path(json.loads(config_file.read_text())["output_raster_file"])
+
+    # Check that the expected result occurred
+    assert output_raster_path.exists()
+    assert output_raster_path.is_file()

--- a/tests/data/remote/clip_raster_cli_test_config.json
+++ b/tests/data/remote/clip_raster_cli_test_config.json
@@ -1,0 +1,5 @@
+{
+    "raster_file": "tests/data/remote/small_raster.tif",
+    "geodataframe_file": "tests/data/remote/small_area.shp",
+    "output_raster_file": "tests/data/local/test.tif"
+}


### PR DESCRIPTION
Added the basic draft of the interface and implemented an entrypoint for
the `eis_toolkit.raster_processing.clipping.clip_raster` function as
`cli-clip-raster`. Naming and many other details are just as examples,
they can be changed as wanted.

Also added the needed boilerplate to make the command-line interface
installable with `pip` and `poetry` in `pyproject.toml`. Furthermore,
for local development and testing primarily, the command-line can be
called with `python -m eis_toolkit`. Use the `--help` option to show the
help. E.g.

~~~bash
poetry run python -m eis_toolkit --help
~~~

Output currently:

~~~
Usage: python -m eis_toolkit [OPTIONS] COMMAND [ARGS]...

  Click group to nest subcommands under one interface.

Options:
  --help  Show this message and exit.

Commands:
  cli-clip-raster  Clip a raster at ``raster_path`` with geometries in...
~~~
