### PR TITLE
Fix Conda Windows GitHub action workflow (Closes #107)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,9 @@ dependencies:
   - rasterio >=1.2.10,<2.0.0
   - pandas >=1.5.3
   - geopandas >=0.12.2,<1.0.0
+  - fiona >=1.8.22,<2.0.0
+  - gdal >=3.0.2,<4.0.0
+  - geos >=3.8.0,<4.0.0
   - scikit-learn >=1.2.1,<2.0.0
   - matplotlib-base >=3.7.0
   - statsmodels >=0.13.5,<1.0.0


### PR DESCRIPTION
The added dependency constraints should allow the conda classic environment solver to create a working environment.