### PR TITLE
Add third-party licenses info and guide (Closes #114)

### DIFF
--- a/docs/dependency_licenses.md
+++ b/docs/dependency_licenses.md
@@ -14,6 +14,7 @@
 | libclang                     | 14.0.6    | Apache Software License                            |
 | requests                     | 2.28.1    | Apache Software License                            |
 | rsa                          | 4.9       | Apache Software License                            |
+| tenacity                     | 8.2.2     | Apache Software License                            |
 | tensorboard                  | 2.9.1     | Apache Software License                            |
 | tensorboard-data-server      | 0.6.1     | Apache Software License                            |
 | tensorflow                   | 2.9.2     | Apache Software License                            |
@@ -70,6 +71,7 @@
 | mkdocs-material              | 8.4.2     | MIT License                                        |
 | mkdocs-material-extensions   | 1.0.3     | MIT License                                        |
 | munch                        | 2.5.0     | MIT License                                        |
+| plotly                       | 5.14.0    | MIT License                                        |
 | pymdown-extensions           | 9.5       | MIT License                                        |
 | pyparsing                    | 3.0.9     | MIT License                                        |
 | pyproj                       | 3.3.1     | MIT License                                        |

--- a/docs/dependency_licenses.md
+++ b/docs/dependency_licenses.md
@@ -1,0 +1,86 @@
+| Name                         | Version   | License                                            |
+|------------------------------|-----------|----------------------------------------------------|
+| protobuf                     | 3.19.4    | 3-Clause BSD License                               |
+| tensorboard-plugin-wit       | 1.8.1     | Apache 2.0                                         |
+| absl-py                      | 1.2.0     | Apache Software License                            |
+| flatbuffers                  | 1.12      | Apache Software License                            |
+| ghp-import                   | 2.1.0     | Apache Software License                            |
+| google-auth                  | 2.11.0    | Apache Software License                            |
+| google-auth-oauthlib         | 0.4.6     | Apache Software License                            |
+| google-pasta                 | 0.2.0     | Apache Software License                            |
+| grpcio                       | 1.48.1    | Apache Software License                            |
+| importlib-metadata           | 4.12.0    | Apache Software License                            |
+| keras                        | 2.9.0     | Apache Software License                            |
+| libclang                     | 14.0.6    | Apache Software License                            |
+| requests                     | 2.28.1    | Apache Software License                            |
+| rsa                          | 4.9       | Apache Software License                            |
+| tensorboard                  | 2.9.1     | Apache Software License                            |
+| tensorboard-data-server      | 0.6.1     | Apache Software License                            |
+| tensorflow                   | 2.9.2     | Apache Software License                            |
+| tensorflow-estimator         | 2.9.0     | Apache Software License                            |
+| tensorflow-io-gcs-filesystem | 0.26.0    | Apache Software License                            |
+| watchdog                     | 2.1.9     | Apache Software License                            |
+| packaging                    | 21.3      | Apache Software License; BSD License               |
+| python-dateutil              | 2.8.2     | Apache Software License; BSD License               |
+| affine                       | 2.3.1     | BSD                                                |
+| cligj                        | 0.7.2     | BSD                                                |
+| geopandas                    | 0.11.1    | BSD                                                |
+| Fiona                        | 1.8.21    | BSD License                                        |
+| Jinja2                       | 3.1.2     | BSD License                                        |
+| Markdown                     | 3.3.7     | BSD License                                        |
+| MarkupSafe                   | 2.1.1     | BSD License                                        |
+| Pygments                     | 2.13.0    | BSD License                                        |
+| Shapely                      | 1.8.4     | BSD License                                        |
+| Werkzeug                     | 2.2.2     | BSD License                                        |
+| astunparse                   | 1.6.3     | BSD License                                        |
+| click                        | 8.1.3     | BSD License                                        |
+| click-plugins                | 1.1.1     | BSD License                                        |
+| cycler                       | 0.11.0    | BSD License                                        |
+| gast                         | 0.4.0     | BSD License                                        |
+| h5py                         | 3.7.0     | BSD License                                        |
+| idna                         | 3.3       | BSD License                                        |
+| joblib                       | 1.1.0     | BSD License                                        |
+| kiwisolver                   | 1.4.4     | BSD License                                        |
+| mkdocs                       | 1.3.1     | BSD License                                        |
+| numpy                        | 1.23.2    | BSD License                                        |
+| oauthlib                     | 3.2.0     | BSD License                                        |
+| pandas                       | 1.4.4     | BSD License                                        |
+| patsy                        | 0.5.2     | BSD License                                        |
+| pyasn1                       | 0.4.8     | BSD License                                        |
+| pyasn1-modules               | 0.2.8     | BSD License                                        |
+| rasterio                     | 1.3.2     | BSD License                                        |
+| requests-oauthlib            | 1.3.1     | BSD License                                        |
+| scikit-learn                 | 1.1.2     | BSD License                                        |
+| scipy                        | 1.9.1     | BSD License                                        |
+| statsmodels                  | 0.13.2    | BSD License                                        |
+| threadpoolctl                | 3.1.0     | BSD License                                        |
+| wrapt                        | 1.14.1    | BSD License                                        |
+| eis-toolkit                  | 0.1.0     | European Union Public Licence 1.2 (EUPL 1.2)       |
+| Pillow                       | 9.2.0     | Historical Permission Notice and Disclaimer (HPND) |
+| opt-einsum                   | 3.3.0     | MIT                                                |
+| snuggs                       | 1.4.7     | MIT                                                |
+| GDAL                         | 3.4.3     | MIT License                                        |
+| Keras-Preprocessing          | 1.1.2     | MIT License                                        |
+| PyYAML                       | 6.0       | MIT License                                        |
+| attrs                        | 22.1.0    | MIT License                                        |
+| cachetools                   | 5.2.0     | MIT License                                        |
+| charset-normalizer           | 2.1.1     | MIT License                                        |
+| fonttools                    | 4.37.1    | MIT License                                        |
+| mergedeep                    | 1.3.4     | MIT License                                        |
+| mkdocs-material              | 8.4.2     | MIT License                                        |
+| mkdocs-material-extensions   | 1.0.3     | MIT License                                        |
+| munch                        | 2.5.0     | MIT License                                        |
+| pymdown-extensions           | 9.5       | MIT License                                        |
+| pyparsing                    | 3.0.9     | MIT License                                        |
+| pyproj                       | 3.3.1     | MIT License                                        |
+| pytz                         | 2022.2.1  | MIT License                                        |
+| pyyaml_env_tag               | 0.1       | MIT License                                        |
+| setuptools-scm               | 6.4.2     | MIT License                                        |
+| six                          | 1.16.0    | MIT License                                        |
+| termcolor                    | 1.1.0     | MIT License                                        |
+| tomli                        | 2.0.1     | MIT License                                        |
+| urllib3                      | 1.26.12   | MIT License                                        |
+| zipp                         | 3.8.1     | MIT License                                        |
+| certifi                      | 2022.6.15 | Mozilla Public License 2.0 (MPL 2.0)               |
+| matplotlib                   | 3.5.3     | Python Software Foundation License                 |
+| typing_extensions            | 4.3.0     | Python Software Foundation License                 |

--- a/instructions/generating_dependency_licenses.md
+++ b/instructions/generating_dependency_licenses.md
@@ -1,0 +1,56 @@
+# Generating dependency license list
+
+The generated list of dependency licenses exists at
+`docs/dependency_licenses.md`. This has been generated with the
+[`pip-licenses`](https://pypi.org/project/pip-licenses/) command-line tool.
+This requires that it is installed in the same virtual environment as the
+packages it is trying to find licenses of. The process of updating the file is
+manual and should be done when new packages are added to `pyproject.toml` or
+`poetry.lock` is updated. However, package updates rarely include license
+changes.
+
+Start by cleaning your local `poetry` environment:
+
+``` shell
+poetry env remove python
+```
+
+Then install only the main dependencies in pyproject.toml (not dev
+dependencies):
+
+``` shell
+poetry install --with main
+# Old poetry version: poetry install --no-dev
+```
+
+Use either i.) poetry to add pip-licenses package (which updates pyproject.toml and
+poetry.lock but these changes should not be committed)
+
+``` shell
+poetry add pip-licenses
+```
+
+ii.) or the pip within the poetry environment:
+
+``` shell
+poetry run pip install pip-licenses
+```
+
+`pip-licenses` is now available in the poetry environment:
+
+``` shell
+poetry run pip-licenses --order=license --format=markdown > docs/dependency_licenses.md
+```
+
+Commit only the `docs/dependency_licenses.md` file. You can restore
+`pyproject.toml` and `poetry.lock` files with `git restore pyproject.toml
+poetry.lock` -command.
+
+To clean your local `poetry` environment:
+
+``` shell
+# Remove poetry environment from the current project
+poetry env remove python
+# Install main and dev packages from pyproject.toml again
+poetry install
+```


### PR DESCRIPTION
Added the licenses table, formatted with `markdown`, and a guide on how to update/reproduce it. See #114.
