### PR TITLE
Add rasterize

### DIFF
--- a/docs/vector_processing/rasterize_vector.md
+++ b/docs/vector_processing/rasterize_vector.md
@@ -1,0 +1,3 @@
+# Rasterize vector
+
+::: eis_toolkit.vector_processing.rasterize_vector

--- a/eis_toolkit/vector_processing/rasterize.py
+++ b/eis_toolkit/vector_processing/rasterize.py
@@ -1,0 +1,110 @@
+from typing import Optional, Tuple
+
+import geopandas as gpd
+import numpy as np
+from rasterio import features, profiles, transform
+
+from eis_toolkit import exceptions
+
+
+def rasterize_vector(
+    geodataframe: gpd.GeoDataFrame,
+    resolution: float,
+    value_column: Optional[str] = None,
+    default_value: float = 1.0,
+    fill_value: float = 0.0,
+    base_raster_profile: Optional[profiles.Profile] = None,
+    buffer_value: Optional[float] = None,
+) -> Tuple[np.ndarray, dict]:
+    """Transform vector data into raster data.
+
+    Args:
+        geodataframe (geopandas.GeoDataFrame): The vector dataframe to be rasterized.
+        resolution (float): The resolution i.e. cell size of the output raster
+        value_column (Optional[str]): The column name with values for each geometry.
+            If None, then default_value is used for all geometries.
+        default_value (int): Default value burned into raster cells based on geometries.
+        fill_value (int): VAlue used outside the burned geometry cells.
+        buffer_value (float): Add buffer around passed geometries before rasterization.
+
+    Returns:
+        out_raster (tuple(numpy.ndarray, dict)): Raster data and metadata.
+    """
+
+    if geodataframe.shape[0] == 0:
+        # Empty GeoDataFrame
+        raise exceptions.EmptyDataFrameException("Expected geodataframe to contain geometries.")
+
+    if not resolution > 0:
+        raise ValueError(f"Expected a positive value resolution ({dict(resolution=resolution)})")
+    if value_column is not None and value_column not in geodataframe.columns:
+        raise ValueError(f"Expected value_column ({value_column}) to be contained in geodataframe columns.")
+    if buffer_value is not None and buffer_value < 0:
+        raise ValueError(f"Expected a positive buffer_value ({dict(buffer_value=buffer_value)})")
+
+    if buffer_value is not None:
+        geodataframe["geometry"] = geodataframe["geometry"].apply(lambda geom: geom.buffer(buffer_value))
+
+    return _rasterize_vector(
+        geodataframe=geodataframe,
+        value_column=value_column,
+        default_value=default_value,
+        fill_value=fill_value,
+        base_raster_profile=base_raster_profile,
+        resolution=resolution,
+    )
+
+
+def _transform_from_geometries(
+    geodataframe: gpd.GeoDataFrame, resolution: float
+) -> Tuple[float, float, transform.Affine]:
+    """Determine transform from the input geometries.
+
+    Returns:
+        width (float): Width of the raster
+        height (float): Height of the raster
+        out_transform (rasterio.transform.Affine): Affine transform of the output
+    """
+    min_x, min_y, max_x, max_y = geodataframe.total_bounds
+    width = (max_x - min_x) / resolution
+    height = (max_y - min_y) / resolution
+
+    out_transform = transform.from_bounds(min_x, min_y, max_x, max_y, width=width, height=height)
+    return width, height, out_transform
+
+
+def _rasterize_vector(
+    geodataframe: gpd.GeoDataFrame,
+    value_column: Optional[str],
+    default_value: float,
+    fill_value: float,
+    base_raster_profile: Optional[profiles.Profile],
+    resolution: float,
+) -> Tuple[np.ndarray, dict]:
+    # rasterio.features.rasterize expects a shapes parameter which is
+    # an iterable of tuples where the first value is a geometry and
+    # the other a value for the geometry
+    # Alternatively, if there are not values for each geometry,
+    # an iterable of geometries can be passed
+    geometries = geodataframe["geometry"].values
+    values = geodataframe[value_column].values if value_column is not None else None
+    geometry_value_pairs = list(geometries) if values is None else list(zip(geometries, values))
+
+    if base_raster_profile is None:
+        width, height, out_transform = _transform_from_geometries(geodataframe=geodataframe, resolution=resolution)
+    else:
+        width, height, out_transform = (
+            base_raster_profile["width"],
+            base_raster_profile["height"],
+            base_raster_profile["transform"],
+        )
+
+    out_raster_array = features.rasterize(
+        shapes=geometry_value_pairs,
+        # fill and default_value can be floats even though typing claims otherwise
+        fill=fill_value,
+        default_value=default_value,
+        transform=out_transform,
+        out_shape=(round(height), round(width)),
+    )
+    return out_raster_array, dict(transform=out_transform, height=height, width=width)

--- a/eis_toolkit/vector_processing/rasterize_vector.py
+++ b/eis_toolkit/vector_processing/rasterize_vector.py
@@ -43,6 +43,7 @@ def rasterize_vector(
         raise ValueError(f"Expected a positive buffer_value ({dict(buffer_value=buffer_value)})")
 
     if buffer_value is not None:
+        geodataframe = geodataframe.copy()
         geodataframe["geometry"] = geodataframe["geometry"].apply(lambda geom: geom.buffer(buffer_value))
 
     return _rasterize_vector(

--- a/eis_toolkit/vector_processing/rasterize_vector.py
+++ b/eis_toolkit/vector_processing/rasterize_vector.py
@@ -1,12 +1,13 @@
-from typing import Optional, Tuple, Union
-
 import geopandas as gpd
 import numpy as np
+from beartype import beartype
+from beartype.typing import Optional, Tuple, Union
 from rasterio import features, profiles, transform
 
 from eis_toolkit import exceptions
 
 
+@beartype
 def rasterize_vector(
     geodataframe: gpd.GeoDataFrame,
     resolution: float,
@@ -19,19 +20,19 @@ def rasterize_vector(
     """Transform vector data into raster data.
 
     Args:
-        geodataframe (geopandas.GeoDataFrame): The vector dataframe to be rasterized.
-        resolution (float): The resolution i.e. cell size of the output raster
-        value_column (Optional[str]): The column name with values for each geometry.
+        geodataframe: The vector dataframe to be rasterized.
+        resolution: The resolution i.e. cell size of the output raster
+        value_column: The column name with values for each geometry.
             If None, then default_value is used for all geometries.
-        default_value (float): Default value burned into raster cells based on geometries.
-        base_raster_profile (Optional[Union[rasterio.profiles.Profile, dict]]): Base raster profile
+        default_value: Default value burned into raster cells based on geometries.
+        base_raster_profile: Base raster profile
             to be used for determining the grid on which vectors are burned in.
-        fill_value (float): VAlue used outside the burned/rasterized geometry cells.
-        buffer_value (Optional[float]): For adding a buffer around passed
+        fill_value: Value used outside the burned/rasterized geometry cells.
+        buffer_value: For adding a buffer around passed
             geometries before rasterization.
 
     Returns:
-        out_raster (tuple(numpy.ndarray, dict)): Rasterized vector data and metadata.
+        Rasterized vector data and metadata.
     """
 
     if geodataframe.shape[0] == 0:
@@ -76,9 +77,7 @@ def _transform_from_geometries(
     """Determine transform from the input geometries.
 
     Returns:
-        width (float): Width of the raster
-        height (float): Height of the raster
-        out_transform (rasterio.transform.Affine): Affine transform of the output
+        Width, height and transform of the raster in a tuple.
     """
     min_x, min_y, max_x, max_y = geodataframe.total_bounds
     width = (max_x - min_x) / resolution
@@ -93,7 +92,7 @@ def _rasterize_vector(
     value_column: Optional[str],
     default_value: float,
     fill_value: float,
-    base_raster_profile: Optional[profiles.Profile],
+    base_raster_profile: Optional[Union[profiles.Profile, dict]],
     resolution: float,
 ) -> Tuple[np.ndarray, dict]:
     # rasterio.features.rasterize expects a shapes parameter which is

--- a/tests/vector_processing/test_rasterize_vector.py
+++ b/tests/vector_processing/test_rasterize_vector.py
@@ -1,0 +1,210 @@
+from contextlib import nullcontext
+
+import geopandas as gpd
+
+# import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from rasterio import profiles, transform
+from shapely.geometry import LineString, Point, box
+
+from eis_toolkit import exceptions
+from eis_toolkit.vector_processing.rasterize import rasterize_vector
+
+SAMPLE_LINE_GEODATAFRAME = gpd.GeoDataFrame(
+    {
+        "geometry": [
+            LineString([(0, 0), (1, 1)]),
+            LineString([(0, 1), (1, 2)]),
+            LineString([(0, 2), (1, 3)]),
+        ],
+        "values": [1, 2, 3],
+    },
+)
+
+SAMPLE_POINT_GEODATAFRAME = gpd.GeoDataFrame(
+    {
+        "geometry": [
+            Point(0, 0),
+            Point(2, 2),
+            Point(10, 10),
+        ],
+        "values": [1, 2, 3],
+    },
+)
+
+SAMPLE_POLYGON_GEODATAFRAME = gpd.GeoDataFrame(
+    {
+        "geometry": [
+            box(0, 0, 2, 2),
+            Point(5, 5).buffer(2.0),
+            LineString([(6, 6), (10, 10)]).buffer(0.5),
+        ],
+        "values": [1, 2, 3],
+    },
+)
+
+SAMPLE_EMPTY_GEODATAFRAME = gpd.GeoDataFrame(
+    {
+        "geometry": [],
+        "values": [],
+    },
+)
+
+SAMPLE_TRACES_WITH_EMPTY_GEODATAFRAME = gpd.GeoDataFrame(
+    {
+        "geometry": [
+            LineString(),
+            LineString([(0, 1), (1, 2)]),
+            LineString([(0, 2), (1, 3)]),
+        ],
+        "values": [1, 2, 3],
+    },
+)
+
+
+@pytest.mark.parametrize(
+    "geodataframe,resolution,value_column,default_value,fill_value,base_raster_profile,buffer_value,raises",
+    [
+        pytest.param(
+            SAMPLE_LINE_GEODATAFRAME,
+            0.05,
+            None,
+            1,
+            0,
+            None,
+            None,
+            nullcontext(),
+            id="LineStrings",
+        ),
+        pytest.param(
+            SAMPLE_POINT_GEODATAFRAME,
+            0.5,
+            None,
+            1,
+            0,
+            None,
+            None,
+            nullcontext(),
+            id="Points",
+        ),
+        pytest.param(
+            SAMPLE_POLYGON_GEODATAFRAME,
+            0.5,
+            None,
+            1,
+            0,
+            None,
+            None,
+            nullcontext(),
+            id="Polygons",
+        ),
+        pytest.param(
+            SAMPLE_EMPTY_GEODATAFRAME,
+            0.5,
+            None,
+            1,
+            0,
+            None,
+            None,
+            pytest.raises(exceptions.EmptyDataFrameException),
+            id="Empty_GeoDataFrame_that_should_raise_exception",
+        ),
+        pytest.param(
+            SAMPLE_TRACES_WITH_EMPTY_GEODATAFRAME,
+            0.5,
+            None,
+            1,
+            0,
+            None,
+            None,
+            nullcontext(),
+            id="LineStrings_with_some_empty",
+        ),
+        pytest.param(
+            SAMPLE_LINE_GEODATAFRAME,
+            0.15,
+            None,
+            1,
+            0,
+            profiles.Profile(
+                dict(height=20, width=20, transform=transform.from_bounds(-10, -10, 10, 10, width=20, height=20))
+            ),
+            None,
+            nullcontext(),
+            id="LineStrings_with_base_raster",
+        ),
+        pytest.param(
+            SAMPLE_LINE_GEODATAFRAME,
+            0.15,
+            None,
+            1,
+            0,
+            None,
+            1.0,
+            nullcontext(),
+            id="LineStrings_with_buffer",
+        ),
+    ],
+)
+def test_rasterize_vector(
+    geodataframe: gpd.GeoDataFrame,
+    resolution,
+    value_column,
+    default_value,
+    fill_value,
+    base_raster_profile,
+    raises,
+    buffer_value,
+):
+    """Test rasterize_vector."""
+    results = None
+    with raises:
+        results = rasterize_vector(
+            geodataframe=geodataframe,
+            resolution=resolution,
+            value_column=value_column,
+            default_value=default_value,
+            fill_value=fill_value,
+            base_raster_profile=base_raster_profile,
+            buffer_value=buffer_value,
+        )
+
+    if results is None:
+        # Expected exception was raised
+        return
+    out_raster_array, out_metadata = results
+    assert isinstance(out_raster_array, np.ndarray)
+    assert isinstance(out_metadata, dict)
+
+    if base_raster_profile is not None:
+        for key in ("transform", "width", "height"):
+            assert out_metadata[key] == base_raster_profile[key]
+
+    # # with rasterio.open(
+    # #         "/mnt/c/tmp/new.tiff",
+    # #         mode="w",
+    # #         driver="GTiff",
+    # #         height=out_raster_array.shape[0],
+    # #         width=out_raster_array.shape[1],
+    # #         count=1,
+    # #         dtype=out_raster_array.dtype,
+    # #         crs=geodataframe.crs,
+    # #         transform=out_metadata["transform"]
+    # #         ) as new_dataset:
+
+    # #     new_dataset.write(out_raster_array, 1)
+    # # geodataframe.to_file("/mnt/c/tmp/new.gpkg", driver="GPKG")
+
+    # fig, ax = plt.subplots()
+    # rasterio_ax = plot.show(out_raster_array, transform=out_metadata["transform"], ax=ax)
+    # fig.colorbar(rasterio_ax.get_images()[0])
+    # geodataframe.plot(ax=ax, alpha=0.5)
+
+    # # min_x, min_y, max_x, max_y = geodataframe.total_bounds
+    # # ax.set_xlim(min_x - (0.1 * max_x), max_x * 1.1)
+    # # ax.set_ylim(min_y - (0.1 * max_y), max_y * 1.1)
+    # name = f"{geodataframe.geometry.values[0].geom_type}
+    # _{resolution}_{value_column}_{base_raster_profile is None}_{buffer_value is not None}"
+    # fig.suptitle(name)
+    # fig.savefig(f"/mnt/c/tmp/new_{name}.png")

--- a/tests/vector_processing/test_rasterize_vector.py
+++ b/tests/vector_processing/test_rasterize_vector.py
@@ -1,5 +1,5 @@
 from contextlib import nullcontext
-from typing import ContextManager, NamedTuple, Optional, Union
+from typing import NamedTuple, Optional, Union
 
 import geopandas as gpd
 import numpy as np
@@ -74,7 +74,6 @@ class RasterizeVectorTestArgs(NamedTuple):
     fill_value: float = 0.0
     base_raster_profile: Optional[Union[profiles.Profile, dict]] = None
     buffer_value: Optional[float] = None
-    raises: ContextManager = nullcontext()
 
 
 @pytest.mark.parametrize(
@@ -82,32 +81,35 @@ class RasterizeVectorTestArgs(NamedTuple):
     [
         pytest.param(
             *RasterizeVectorTestArgs(geodataframe=SAMPLE_LINE_GEODATAFRAME, resolution=0.05),
+            nullcontext(),
             id="LineStrings",
         ),
         pytest.param(
             *RasterizeVectorTestArgs(geodataframe=SAMPLE_POINT_GEODATAFRAME, resolution=0.5),
+            nullcontext(),
             id="Points",
         ),
         pytest.param(
             *RasterizeVectorTestArgs(
                 geodataframe=SAMPLE_POINT_GEODATAFRAME,
                 resolution=-0.5,
-                raises=pytest.raises(exceptions.NumericValueSignException),
             ),
+            pytest.raises(exceptions.NumericValueSignException),
             id="Points_with_negative_resolution",
         ),
         pytest.param(
             *RasterizeVectorTestArgs(geodataframe=SAMPLE_POLYGON_GEODATAFRAME),
+            nullcontext(),
             id="Polygons",
         ),
         pytest.param(
-            *RasterizeVectorTestArgs(
-                geodataframe=SAMPLE_EMPTY_GEODATAFRAME, raises=pytest.raises(exceptions.EmptyDataFrameException)
-            ),
+            *RasterizeVectorTestArgs(geodataframe=SAMPLE_EMPTY_GEODATAFRAME),
+            pytest.raises(exceptions.EmptyDataFrameException),
             id="Empty_GeoDataFrame_that_should_raise_exception",
         ),
         pytest.param(
             *RasterizeVectorTestArgs(geodataframe=SAMPLE_TRACES_WITH_EMPTY_GEODATAFRAME),
+            nullcontext(),
             id="LineStrings_with_some_empty",
         ),
         pytest.param(
@@ -117,18 +119,20 @@ class RasterizeVectorTestArgs(NamedTuple):
                     dict(height=20, width=20, transform=transform.from_bounds(-10, -10, 10, 10, width=20, height=20))
                 ),
             ),
+            nullcontext(),
             id="LineStrings_with_base_raster",
         ),
         pytest.param(
             *RasterizeVectorTestArgs(geodataframe=SAMPLE_LINE_GEODATAFRAME, buffer_value=1.0, resolution=0.15),
+            nullcontext(),
             id="LineStrings_with_buffer",
         ),
         pytest.param(
             *RasterizeVectorTestArgs(
                 geodataframe=SAMPLE_LINE_GEODATAFRAME,
                 value_column="not-in-columns",
-                raises=pytest.raises(exceptions.InvalidParameterValueException),
             ),
+            pytest.raises(exceptions.InvalidParameterValueException),
             id="Invalid_value_column",
         ),
     ],
@@ -172,13 +176,15 @@ def test_rasterize_vector(
     "geodataframe,resolution,value_column,default_value,fill_value,base_raster_profile,buffer_value,expected_result",
     [
         pytest.param(
-            SAMPLE_LINE_GEODATAFRAME,
-            0.25,
-            None,
-            1,
-            0,
-            None,
-            None,
+            *RasterizeVectorTestArgs(
+                geodataframe=SAMPLE_LINE_GEODATAFRAME,
+                resolution=0.25,
+                value_column=None,
+                default_value=1.0,
+                fill_value=0.0,
+                base_raster_profile=None,
+                buffer_value=None,
+            ),
             np.array(
                 [
                     [0, 0, 0, 0],
@@ -199,13 +205,15 @@ def test_rasterize_vector(
             id="LineStrings",
         ),
         pytest.param(
-            SAMPLE_POINT_GEODATAFRAME,
-            0.5,
-            None,
-            1,
-            0,
-            None,
-            0.5,
+            *RasterizeVectorTestArgs(
+                geodataframe=SAMPLE_POINT_GEODATAFRAME,
+                resolution=0.5,
+                value_column=None,
+                default_value=1.0,
+                fill_value=0.0,
+                base_raster_profile=None,
+                buffer_value=0.5,
+            ),
             np.array(
                 [
                     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1],


### PR DESCRIPTION
Added rasterization of vector geometries as discussed in #102. Contains
capabilities for all geometry types and allows adding a buffer around the
geometries to increase the subsequent raster cell area that is burned by the
geometry.

Added tests for the basic geometry types, using a base raster (profile) and
buffering input geometries.

Ready for review as of 14.4.2023.
