### PR TITLE
Add density computations

### DIFF
--- a/docs/vector_processing/vector_density.md
+++ b/docs/vector_processing/vector_density.md
@@ -1,0 +1,3 @@
+# Compute vector density
+
+::: eis_toolkit.vector_processing.vector_density

--- a/eis_toolkit/vector_processing/vector_density.py
+++ b/eis_toolkit/vector_processing/vector_density.py
@@ -1,7 +1,7 @@
 import geopandas as gpd
 import numpy as np
 from beartype import beartype
-from beartype.typing import Optional, Tuple, Union
+from beartype.typing import Literal, Optional, Tuple, Union
 from rasterio import profiles
 
 from eis_toolkit.vector_processing.rasterize_vector import rasterize_vector
@@ -13,6 +13,7 @@ def vector_density(
     resolution: Optional[float] = None,
     base_raster_profile: Optional[Union[profiles.Profile, dict]] = None,
     buffer_value: Optional[float] = None,
+    statistic: Literal["density", "count"] = "density",
 ) -> Tuple[np.ndarray, dict]:
     """Compute density of geometries within raster.
 
@@ -31,7 +32,7 @@ def vector_density(
     Returns:
         Computed density of vector data and metadata.
     """
-    return rasterize_vector(
+    out_raster_array, out_metadata = rasterize_vector(
         geodataframe=geodataframe,
         resolution=resolution,
         base_raster_profile=base_raster_profile,
@@ -41,3 +42,8 @@ def vector_density(
         fill_value=0.0,
         merge_strategy="add",
     )
+    max_count = np.max(out_raster_array)
+    if statistic == "count" or np.isclose(max_count, 0.0):
+        return out_raster_array, out_metadata
+    else:
+        return (out_raster_array / max_count), out_metadata

--- a/eis_toolkit/vector_processing/vector_density.py
+++ b/eis_toolkit/vector_processing/vector_density.py
@@ -1,0 +1,43 @@
+import geopandas as gpd
+import numpy as np
+from beartype import beartype
+from beartype.typing import Optional, Tuple, Union
+from rasterio import profiles
+
+from eis_toolkit.vector_processing.rasterize_vector import rasterize_vector
+
+
+@beartype
+def vector_density(
+    geodataframe: gpd.GeoDataFrame,
+    resolution: Optional[float] = None,
+    base_raster_profile: Optional[Union[profiles.Profile, dict]] = None,
+    buffer_value: Optional[float] = None,
+) -> Tuple[np.ndarray, dict]:
+    """Compute density of geometries within raster.
+
+    Args:
+        geodataframe: The dataframe with vectors
+            of which density is computed.
+        resolution: The resolution i.e. cell size of the output raster.
+            Optional if base_raster_profile is given.
+        base_raster_profile: Base raster profile
+            to be used for determining the grid on which vectors are
+            burned in. If None, the geometries and provided resolution
+            value are used to compute grid.
+        buffer_value: For adding a buffer around passed
+            geometries before computing density.
+
+    Returns:
+        Computed density of vector data and metadata.
+    """
+    return rasterize_vector(
+        geodataframe=geodataframe,
+        resolution=resolution,
+        base_raster_profile=base_raster_profile,
+        buffer_value=buffer_value,
+        value_column=None,
+        default_value=1.0,
+        fill_value=0.0,
+        merge_strategy="add",
+    )

--- a/tests/vector_processing/test_vector_density.py
+++ b/tests/vector_processing/test_vector_density.py
@@ -1,0 +1,60 @@
+import geopandas as gpd
+import numpy as np
+import pytest
+
+from eis_toolkit.vector_processing.vector_density import vector_density
+from tests.vector_processing.test_rasterize_vector import SAMPLE_OVERLAPPING_POINT_GEODATAFRAME
+
+
+@pytest.mark.parametrize(
+    "geodataframe,resolution,base_raster_profile,buffer_value,expected_result",
+    [
+        pytest.param(
+            SAMPLE_OVERLAPPING_POINT_GEODATAFRAME,
+            0.5,
+            None,
+            0.5,
+            np.array(
+                [
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                ],
+                dtype=np.uint8,
+            ),
+            id="Overlapping_points_with_small_buffer",
+        ),
+    ],
+)
+def test_vector_density_with_known_result(
+    geodataframe: gpd.GeoDataFrame,
+    resolution,
+    base_raster_profile,
+    buffer_value,
+    expected_result,
+):
+    """Test vector_density."""
+    out_raster_array, out_metadata = vector_density(
+        geodataframe=geodataframe,
+        resolution=resolution,
+        base_raster_profile=base_raster_profile,
+        buffer_value=buffer_value,
+    )
+
+    assert isinstance(out_raster_array, np.ndarray)
+    assert isinstance(out_metadata, dict)
+
+    if base_raster_profile is not None:
+        for key in ("transform", "width", "height"):
+            assert out_metadata[key] == base_raster_profile[key]
+
+    np.testing.assert_array_equal(out_raster_array, expected_result)

--- a/tests/vector_processing/test_vector_density.py
+++ b/tests/vector_processing/test_vector_density.py
@@ -7,13 +7,14 @@ from tests.vector_processing.test_rasterize_vector import SAMPLE_OVERLAPPING_POI
 
 
 @pytest.mark.parametrize(
-    "geodataframe,resolution,base_raster_profile,buffer_value,expected_result",
+    "geodataframe,resolution,base_raster_profile,buffer_value,statistic,expected_result",
     [
         pytest.param(
             SAMPLE_OVERLAPPING_POINT_GEODATAFRAME,
             0.5,
             None,
             0.5,
+            "count",
             np.array(
                 [
                     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2],
@@ -31,7 +32,31 @@ from tests.vector_processing.test_rasterize_vector import SAMPLE_OVERLAPPING_POI
                 ],
                 dtype=np.uint8,
             ),
-            id="Overlapping_points_with_small_buffer",
+            id="Overlapping_points_with_small_buffer_count",
+        ),
+        pytest.param(
+            SAMPLE_OVERLAPPING_POINT_GEODATAFRAME,
+            0.5,
+            None,
+            0.5,
+            "density",
+            np.array(
+                [
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    [1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    [1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                ]
+            ),
+            id="Overlapping_points_with_small_buffer_density",
         ),
     ],
 )
@@ -40,6 +65,7 @@ def test_vector_density_with_known_result(
     resolution,
     base_raster_profile,
     buffer_value,
+    statistic,
     expected_result,
 ):
     """Test vector_density."""
@@ -48,6 +74,7 @@ def test_vector_density_with_known_result(
         resolution=resolution,
         base_raster_profile=base_raster_profile,
         buffer_value=buffer_value,
+        statistic=statistic,
     )
 
     assert isinstance(out_raster_array, np.ndarray)


### PR DESCRIPTION
Simply consists of small added modularization to the already done `rasterize_vector.py` file and a new simple entrypoint for the density computation (`vector_density.py`) that uses the more modularized `rasterize_vector.py` and already existing functionality.
