### PR TITLE
Force check_minimax_position to return bool

### DIFF
--- a/eis_toolkit/utilities/checks/parameter.py
+++ b/eis_toolkit/utilities/checks/parameter.py
@@ -68,4 +68,4 @@ def check_minmax_position(parameter: tuple) -> bool:  # type: ignore[no-untyped-
     Returns:
         Bool: True if minimum value < maxiumum value, else False.
     """
-    return parameter[0] < parameter[1]
+    return bool(parameter[0] < parameter[1])


### PR DESCRIPTION
In some cases the function returned np.bool_ instead of bool causing BeartypeCallHintReturnViolation error. Now check_minimax_position is enforced to return bool.