### PR TITLE
Extend conda installation guidace in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ pip install eis_toolkit
 
 ```console
 conda install -c conda-forge eis_toolkit
+# On Windows, tensorflow must be installed from the anaconda channel
+# Consequently, channel priority must be flexible, which can be explicitly
+# done using --no-channel-priority
+conda install -c conda-forge eis_toolkit --no-channel-priority
 ```
 
 A Python wheel can be downloaded also from the [releases page](https://github.com/GispoCoding/eis_toolkit/releases) of this GitHub repository.


### PR DESCRIPTION
Many conda users set the channel priority to strict as part of other guides on conda. Consequently, the installation on Windows will fail as it can not install the updated version of tensorflow from the anaconda channel (part of defaults).
