### PR TITLE
Add WofE CLI functions

### DIFF
--- a/eis_toolkit/cli.py
+++ b/eis_toolkit/cli.py
@@ -3124,7 +3124,7 @@ def weights_of_evidence_calculate_weights_cli(
 
     typer.echo(f"Number of deposit pixels: {nr_of_deposits}")
     typer.echo(f"Number of all evidence pixels: {nr_of_pixels}")
-    typer.echo(f"Results saved in {output_dir}.")
+    typer.echo(f"Weight calculations completed, rasters and CSV saved to {output_dir}.")
 
 
 @app.command()
@@ -3178,8 +3178,6 @@ def weights_of_evidence_calculate_responses_cli(
         dst.write(confidence_array, 1)
 
     typer.echo("Progress: 100%")
-
-    # typer.echo(f"Results saved in {output_dir}.")
 
 
 # --- TRANSFORMATIONS ---

--- a/eis_toolkit/cli.py
+++ b/eis_toolkit/cli.py
@@ -3210,6 +3210,36 @@ def weights_of_evidence_calculate_responses_cli(
     )
 
 
+@app.command()
+def agterberg_cheng_CI_test_cli(
+    input_posterior_probabilities: INPUT_FILE_OPTION,
+    input_posterior_probabilities_std: INPUT_FILE_OPTION,
+    nr_of_deposits: Annotated[int, typer.Option()],
+):
+    """Perform the conditional independence test presented by Agterberg-Cheng (2002)."""
+    from eis_toolkit.prediction.weights_of_evidence import agterberg_cheng_CI_test
+
+    typer.echo("Progress: 10%")
+
+    with rasterio.open(input_posterior_probabilities) as src:
+        posterior_probabilities = src.read(1)
+
+    with rasterio.open(input_posterior_probabilities_std) as src:
+        posterior_probabilities_std = src.read(1)
+
+    typer.echo("Progress: 25%")
+
+    _, _, _, _, summary = agterberg_cheng_CI_test(
+        posterior_probabilities=posterior_probabilities,
+        posterior_probabilities_std=posterior_probabilities_std,
+        nr_of_deposits=nr_of_deposits,
+    )
+
+    typer.echo("Progress: 100%")
+    typer.echo("Conditional independence test completed.")
+    typer.echo(summary)
+
+
 # --- TRANSFORMATIONS ---
 
 

--- a/eis_toolkit/cli.py
+++ b/eis_toolkit/cli.py
@@ -3131,8 +3131,11 @@ def weights_of_evidence_calculate_weights_cli(
     typer.echo("Progress: 75%")
 
     df.to_csv(output_dir.joinpath("wofe_results.csv"))
+
+    file_name = input_raster.name.split(".")[0]
     for key, array in arrays.items():
-        output_raster_path = output_dir.joinpath(key + ".tif")
+        output_raster_path = output_dir.joinpath(file_name + "_weights_" + weights_type + "_" + key + ".tif")
+        typer.echo(output_raster_path)
         with rasterio.open(output_raster_path, "w", **raster_meta) as dst:
             dst.write(array, 1)
 

--- a/eis_toolkit/cli.py
+++ b/eis_toolkit/cli.py
@@ -3179,6 +3179,11 @@ def weights_of_evidence_calculate_responses_cli(
 
     typer.echo("Progress: 100%")
 
+    typer.echo(
+        f"Responses calculations finished, writing output rasters to {output_probabilities}, \
+            {output_probabilities_std} and {output_confidence_array}"
+    )
+
 
 # --- TRANSFORMATIONS ---
 

--- a/eis_toolkit/cli.py
+++ b/eis_toolkit/cli.py
@@ -3090,8 +3090,11 @@ def weights_of_evidence_calculate_weights_cli(
     Parameter --studentized-contrast-threshold is used with 'categorical', 'ascending' and 'descending' weight types.
 
     Parameter --arrays-to-generate controls which columns in the weights dataframe are returned as arrays. All column
-    names in the produced weights_df are valid choices. Defaults to ["Class", "W+", "S_W+] for "unique" weights_type
-    and ["Class", "W+", "S_W+", "Generalized W+", "Generalized S_W+"] for the cumulative weight types.
+    names in the produced weights_df are valid choices. The available columns for "unique" weights_type are "Class",
+    "Pixel count", "Deposit count", "W+", "S_W+", "W-", "S_W-", "Contrast", "S_Contrast", and "Studentized contrast".
+    For other weights types, additional available column names are "Generalized class", "Generalized W+", and
+    "Generalized S_W+". Defaults to ["Class", "W+", "S_W+] for "unique" weights_type and ["Class", "W+", "S_W+",
+    "Generalized W+", "Generalized S_W+"] for the cumulative weight types.
     """
     from eis_toolkit.prediction.weights_of_evidence import weights_of_evidence_calculate_weights
 

--- a/eis_toolkit/cli.py
+++ b/eis_toolkit/cli.py
@@ -3135,7 +3135,6 @@ def weights_of_evidence_calculate_weights_cli(
     file_name = input_raster.name.split(".")[0]
     for key, array in arrays.items():
         output_raster_path = output_dir.joinpath(file_name + "_weights_" + weights_type + "_" + key + ".tif")
-        typer.echo(output_raster_path)
         with rasterio.open(output_raster_path, "w", **raster_meta) as dst:
             dst.write(array, 1)
 

--- a/eis_toolkit/prediction/weights_of_evidence.py
+++ b/eis_toolkit/prediction/weights_of_evidence.py
@@ -374,9 +374,11 @@ def weights_of_evidence_calculate_weights(
             that class with max contrast has studentized contrast value at least the defined value (cumulative).
             Defaults to 1.
         arrays_to_generate: Arrays to generate from the computed weight metrics. All column names
-            in the produced weights_df are valid choices. Defaults to ["Class", "W+", "S_W+]
-            for "unique" weights_type and ["Class", "W+", "S_W+", "Generalized W+", "Generalized S_W+"]
-            for the cumulative weight types.
+            in the produced weights_df are valid choices. Available column names for "unique" weights type are "Class",
+            "Pixel count", "Deposit count", "W+", "S_W+", "W-", "S_W-", "Contrast", "S_Contrast", and
+            "Studentized contrast". For other weights types, additional available column names are "Generalized class",
+            "Generalzed W+", and "Generalized S_W+". Defaults to ["Class", "W+", "S_W+] for "unique" weights_type and
+            ["Class", "W+", "S_W+", "Generalized W+", "Generalized S_W+"] for the cumulative weight types.
 
     Returns:
         Dataframe with weights of spatial association between the input data.


### PR DESCRIPTION
This PR adds CLI functions for the two WofE functions.

In the first CLI function (`weights_of_evidence_calculate_weights_cli`), the resulting dataframe is saved into a CSV file and the arrays are saved as rasters. The number of deposit pixels and evidence pixels are only printed to the user.

In the second CLI function (`weights_of_evidence_calculate_responses_cli`), the resulting probability and confidence arrays are saved as rasters.

In the latter CLI function, there are at least two options how to transform the input rasters into an array of dictionaries needed in the corresponding toolkit function: 
- Create dictionaries based on the number of input rasters and assign key-array pairs so that each dictionary has got the same keys, for example W+ and S_W+ (remove any uncommon keys), or
- read rasters into dictionaries based on their file path. This assumes that each set of outputs of `weights_of_evidence_calculate_weights_cli` are in separate folders. As many dictionaries will be created as there are distinct (innermost) folders in the paths of the input rasters. I'm not sure whether this approach will work with the plugin.

I believe the first approach makes more sense, but I'll let you comment which approach you prefer @nmaarnio.